### PR TITLE
Fix Principal for unauth'ed role

### DIFF
--- a/lib/cdk-starter-stack.ts
+++ b/lib/cdk-starter-stack.ts
@@ -68,7 +68,7 @@ export class CdkStarterStack extends cdk.Stack {
               'cognito-identity.amazonaws.com:aud': identityPool.ref,
             },
             'ForAnyValue:StringLike': {
-              'cognito-identity.amazonaws.com:amr': 'authenticated',
+              'cognito-identity.amazonaws.com:amr': 'unauthenticated',
             },
           },
           'sts:AssumeRoleWithWebIdentity',


### PR DESCRIPTION
Looks like there was a typo in the unauthenticated role principal which would cause the resulting identity provider to end up in a misconfigured state